### PR TITLE
Port features to rendergraph, fix stroke composition, fix baked distortion becoming invalid.

### DIFF
--- a/Runtime/Data/DefaultScriptables/DefaultSketchOutlineStroke.asset
+++ b/Runtime/Data/DefaultScriptables/DefaultSketchOutlineStroke.asset
@@ -16,16 +16,16 @@ MonoBehaviour:
     OriginPoint: {x: 0, y: 0, z: 0, w: 0}
     Direction: {x: 1, y: 0, z: 0, w: 0}
     AdditionalPackedData: {x: 0, y: 0, z: 0, w: 0}
-    Thickness: 1
-    ThicknessFalloffConstraint: 0.448
+    Thickness: 0.35
+    ThicknessFalloffConstraint: 0
     Length: 0.994
-    LengthThicknessFalloff: 0.147
+    LengthThicknessFalloff: 1
     Pressure: 1
-    PressureFalloff: 0
+    PressureFalloff: 1
     Iterations: 0
   SelectedFalloffFunction: 0
   VariationData:
-    DirectionVariationRange: 0.141
-    ThicknessVariationRange: 0
-    LengthVariationRange: 0.076
+    DirectionVariationRange: 0.079
+    ThicknessVariationRange: 1
+    LengthVariationRange: 0
     PressureVariationRange: 0

--- a/Runtime/Data/DefaultScriptables/SketchRendererContext.asset
+++ b/Runtime/Data/DefaultScriptables/SketchRendererContext.asset
@@ -48,31 +48,31 @@ MonoBehaviour:
     ToneScales: {x: 8, y: 8}
     LuminanceScalar: -0.323
   EdgeDetectionFeatureData:
-    Method: 0
-    Source: 3
+    Method: 1
+    Source: 2
     OutlineThreshold: 0.048
     OutlineOffset: 0
     OutlineDistanceFalloff: 0.452
     OutlineAngleSensitivity: 1
     OutlineAngleConstraint: 0.36
     OutlineNormalSensitivity: 0.683
-    OutputType: 0
-  UseSmoothOutlineFeature: 0
+    OutputType: 2
+  UseSmoothOutlineFeature: 1
   AccentedOutlineFeatureData:
     UseAccentedOutlines: 1
     BakeDistortionDuringRuntime: 1
     Rate: 20
-    Strength: 0.368
+    Strength: 0.551
     AdditionalLines: 3
-    AdditionalLineTintPersistence: 0.968
-    AdditionalLineDistortionJitter: 0.102
+    AdditionalLineTintPersistence: 0.61
+    AdditionalLineDistortionJitter: 0.283
     PencilOutlineMask: {fileID: 0}
     MaskScale: {x: 1, y: 1}
     ForceRebake: 1
   ThicknessDilationFeatureData:
     ThicknessRange: 0
-    ThicknessStrength: 1
-  UseSketchyOutlineFeature: 1
+    ThicknessStrength: 0
+  UseSketchyOutlineFeature: 0
   SketchyOutlineFeatureData:
     OutlineStrokeData: {fileID: 11400000, guid: 9a8345853514edd4897fc3587cf35f53, type: 2}
     SampleArea: 1
@@ -84,9 +84,9 @@ MonoBehaviour:
     UsePerpendicularDirection: 0
   CompositionFeatureData:
     debugMode: 0
-    OutlineStrokeColor: {r: 0, g: 0, b: 0, a: 1}
-    ShadingStrokeColor: {r: 0, g: 0, b: 0, a: 1}
-    MaterialAccumulationStrength: 0.246
+    OutlineStrokeColor: {r: 0, g: 0, b: 0, a: 0.8509804}
+    ShadingStrokeColor: {r: 0, g: 0, b: 0, a: 0.92156863}
+    MaterialAccumulationStrength: 0.13
     StrokeBlendMode: 0
-    BlendStrength: 0.982
-    featuresToCompose: 0000000002000000030000000400000005000000
+    BlendStrength: 0.963
+    featuresToCompose: 0000000001000000030000000400000005000000

--- a/Runtime/Rendering/RendererFeatures/Outlining/EdgeDetection/EdgeDetectionRenderPass.cs
+++ b/Runtime/Rendering/RendererFeatures/Outlining/EdgeDetection/EdgeDetectionRenderPass.cs
@@ -27,6 +27,10 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
         protected LocalKeyword outputGreyscaleKeyword;
         protected LocalKeyword outputDirectionAngleDataKeyword;
         protected LocalKeyword outputDirectionVectorDataKeyword;
+        
+        // Scale bias is used to control how the blit operation is done. The x and y parameter controls the scale
+        // and z and w controls the offset.
+        static protected Vector4 scaleBias = new Vector4(1f, 1f, 0f, 0f);
 
         public virtual void Setup(EdgeDetectionPassData passData, Material mat)
         {
@@ -75,6 +79,18 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
         }
 
         public virtual void Dispose() {}
+        
+        protected class BlitPassData
+        {
+            public TextureHandle src;
+            public int passID;
+            public Material mat;
+        }
+        
+        protected static void ExecuteSobelEdgePass(BlitPassData data, RasterGraphContext context)
+        {
+            Blitter.BlitTexture(context.cmd, data.src, scaleBias, data.mat, data.passID);
+        }
         
         public abstract override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData);
     }

--- a/Runtime/Rendering/RendererFeatures/Outlining/EdgeDetection/Passes/DepthNormalsSilhouetteRenderPass.cs
+++ b/Runtime/Rendering/RendererFeatures/Outlining/EdgeDetection/Passes/DepthNormalsSilhouetteRenderPass.cs
@@ -56,16 +56,18 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
                     break;
             }
         }
+        
+        
 
         public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
         {
             var resourceData = frameData.Get<UniversalResourceData>();
-            
+
             if (resourceData.isActiveTargetBackBuffer)
                 return;
 
             var sketchData = frameData.GetOrCreate<SketchFrameData>();
-            
+
             var dstDesc = renderGraph.GetTextureDesc(resourceData.activeColorTexture);
             dstDesc.name = IsSecondary ? OUTLINE_SECONDARY_TEXTURE_NAME : OUTLINE_TEXTURE_NAME;
             dstDesc.format = GraphicsFormat.R8G8B8A8_UNorm;
@@ -75,18 +77,40 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
 
             TextureHandle dst = renderGraph.CreateTexture(dstDesc);
             TextureHandle ping = renderGraph.CreateTexture(dstDesc);
-
-            if (passData.Method == EdgeDetectionGlobalData.EdgeDetectionMethod.SOBEL_1X3 || passData.Method == EdgeDetectionGlobalData.EdgeDetectionMethod.SOBEL_3X3)
+            
+            //Pass 0 = Sobel Horizontal Pass
+            using (var builder = renderGraph.AddRasterRenderPass(PassName + "_Horizontal", out BlitPassData blitPassData))
             {
-                //Pass 0 = Sobel Horizontal Pass
-                RenderGraphUtils.BlitMaterialParameters horParams = new(dst, ping, edgeDetectionMaterial, 0);
-                renderGraph.AddBlitPass(horParams, passName: PassName + "_SobelHorizontal");
-                //Pass 1 = Sobel Vertical Pass
-                RenderGraphUtils.BlitMaterialParameters verParams = new(ping, dst, edgeDetectionMaterial, 1);
-                renderGraph.AddBlitPass(verParams, passName: PassName + "_SobelVertical");
+                if (passData.Method == EdgeDetectionGlobalData.EdgeDetectionMethod.SOBEL_1X3 ||
+                    passData.Method == EdgeDetectionGlobalData.EdgeDetectionMethod.SOBEL_3X3)
+                {
+                    blitPassData.mat = edgeDetectionMaterial;
+                    builder.UseTexture(resourceData.activeColorTexture, AccessFlags.Read);
+                    blitPassData.src = resourceData.activeColorTexture;
+                    blitPassData.passID = 0;
+                    
+                    builder.SetRenderAttachment(ping, 0, AccessFlags.ReadWrite);
+                    builder.SetRenderFunc((BlitPassData passData, RasterGraphContext context) => ExecuteSobelEdgePass(passData, context));
+                }
             }
             
-            if(!IsSecondary)
+            //Pass 1 = Sobel Vertical Pass
+            using (var builder = renderGraph.AddRasterRenderPass(PassName + "_Vertical", out BlitPassData blitPassData))
+            {
+                if (passData.Method == EdgeDetectionGlobalData.EdgeDetectionMethod.SOBEL_1X3 ||
+                    passData.Method == EdgeDetectionGlobalData.EdgeDetectionMethod.SOBEL_3X3)
+                {
+                    blitPassData.mat = edgeDetectionMaterial;
+                    builder.UseTexture(ping, AccessFlags.Read);
+                    blitPassData.src = ping;
+                    blitPassData.passID = 1;
+                    
+                    builder.SetRenderAttachment(dst, 0, AccessFlags.ReadWrite);
+                    builder.SetRenderFunc((BlitPassData passData, RasterGraphContext context) => ExecuteSobelEdgePass(passData, context));
+                }
+            }
+
+            if (!IsSecondary)
                 sketchData.OutlinesTexture = dst;
             else
                 sketchData.OutlinesSecondaryTexture = dst;

--- a/Runtime/Rendering/RendererFeatures/Outlining/SmoothOutline/AccentedOutlinePass/AccentedOutlinePassData.cs
+++ b/Runtime/Rendering/RendererFeatures/Outlining/SmoothOutline/AccentedOutlinePass/AccentedOutlinePassData.cs
@@ -11,6 +11,7 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
         public bool UseAccentedOutlines;
         [Header("Distortion Settings")] 
         public bool BakeDistortionDuringRuntime;
+        public float BakedTextureScaleFactor = 1f;
         public float Rate = 20f;
         [Range(0f, 1f)]
         public float Strength = 0.3f;

--- a/Runtime/Rendering/RendererFeatures/Outlining/SmoothOutline/AccentedOutlinePass/AccentedOutlinePassData.cs
+++ b/Runtime/Rendering/RendererFeatures/Outlining/SmoothOutline/AccentedOutlinePass/AccentedOutlinePassData.cs
@@ -65,9 +65,8 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
             AccentedOutlinePassData overrideData = new AccentedOutlinePassData();
             
             overrideData.UseAccentedOutlines = volumeComponent.UseAccentedOutlines.overrideState ? volumeComponent.UseAccentedOutlines.value : UseAccentedOutlines;
-            overrideData.BakeDistortionDuringRuntime = volumeComponent.BakeDistortion.overrideState
-                ? volumeComponent.BakeDistortion.value
-                : BakeDistortionDuringRuntime;
+            overrideData.BakeDistortionDuringRuntime = volumeComponent.BakeDistortion.overrideState ? volumeComponent.BakeDistortion.value : BakeDistortionDuringRuntime;
+            overrideData.BakedTextureScaleFactor = volumeComponent.BakedDistortionTextureScale.overrideState ? volumeComponent.BakedDistortionTextureScale.value : BakedTextureScaleFactor;
             overrideData.Rate = volumeComponent.DistortionRate.overrideState ? volumeComponent.DistortionRate.value : Rate;
             overrideData.Strength = volumeComponent.DistortionStrength.overrideState ? volumeComponent.DistortionStrength.value : Strength;
             overrideData.AdditionalLines = volumeComponent.AdditionalDistortionLines.overrideState ? volumeComponent.AdditionalDistortionLines.value : AdditionalLines;

--- a/Runtime/Rendering/RendererFeatures/Outlining/SmoothOutline/AccentedOutlinePass/AccentedOutlineRenderPass.cs
+++ b/Runtime/Rendering/RendererFeatures/Outlining/SmoothOutline/AccentedOutlinePass/AccentedOutlineRenderPass.cs
@@ -42,6 +42,10 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
         private LocalKeyword BakeDistortionKeyword;
         private LocalKeyword MultipleDistortionKeyword;
         private LocalKeyword MaskKeyword;
+        
+        // Scale bias is used to control how the blit operation is done. The x and y parameter controls the scale
+        // and z and w controls the offset.
+        static Vector4 scaleBias = new Vector4(1f, 1f, 0f, 0f);
 
         public void Setup(AccentedOutlinePassData passData, Material mat)
         {
@@ -51,7 +55,6 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
             renderPassEvent = RenderPassEvent.BeforeRenderingPostProcessing;
             requiresIntermediateTexture = false;
             
-            ConfigureBakedTextures();
             ConfigureMaterial();
         }
 
@@ -83,29 +86,37 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
             accentedMaterial.SetFloat(additionalLinesTintShaderID, passData.AdditionalLineTintPersistence);
             accentedMaterial.SetFloat(additionalLinesStrengthShaderID, passData.AdditionalLineDistortionJitter);
         }
+        
+        private Vector2Int GetTargetBakedResolution(TextureDesc desc, Vector2 scaleFactor) => new Vector2Int(Mathf.RoundToInt(desc.width * scaleFactor.x), Mathf.RoundToInt(desc.height * scaleFactor.y));
 
-        public void ConfigureBakedTextures()
+        private bool ReValidateBakedTextures(TextureDesc desc)
+        {
+            Vector2Int resolution = GetTargetBakedResolution(desc, Vector2.one * passData.BakedTextureScaleFactor);
+                
+            return bakedDistortionTexture == null || (bakedDistortionTexture != null && (bakedDistortionTexture.rt.width != resolution.x || bakedDistortionTexture.rt.height != resolution.y));
+        }
+
+        public void ConfigureBakedTextures(TextureDesc desc, bool forceBake = false)
         {
             if (this.passData.BakeDistortionDuringRuntime)
             {
-                Vector2 scaleFactor = Vector2.one;
+                Vector2Int resolution = GetTargetBakedResolution(desc, Vector2.one * passData.BakedTextureScaleFactor);
                 
-                //If there are more than two lines, instead assign two textures
-                //TODO: Consider halfing resolution if using more than one texture. Less quality.
-                /*
-                if (passData.RequireMultipleTextures)
-                    scaleFactor *= 0.5f;
-                */
 
-                if (bakedDistortionTexture == null || passData.ForceRebake)
+                if (bakedDistortionTexture == null || passData.ForceRebake || forceBake)
                 {
-                    bakedDistortionTexture = RTHandles.Alloc(scaleFactor, GraphicsFormat.R8G8B8A8_UNorm,
-                        enableRandomWrite: true, name: "_BakedUVDistortionTex");
+                    if (bakedDistortionTexture != null)
+                        bakedDistortionTexture.Release();
+                    bakedDistortionTexture = RTHandles.Alloc(resolution.x, resolution.y, GraphicsFormat.R8G8B8A8_UNorm, enableRandomWrite: true, name: "_BakedUVDistortionTex");
+                    accentedMaterial.SetTexture(bakedDistortionTexShaderID, bakedDistortionTexture);
                 }
                 //Only rebuild this if it is being used
-                if (this.passData.RequireMultipleTextures && (bakedDistortionTexture2 == null || passData.ForceRebake))
+                if (this.passData.RequireMultipleTextures && (bakedDistortionTexture2 == null || passData.ForceRebake || forceBake))
                 {
-                    bakedDistortionTexture2 = RTHandles.Alloc(scaleFactor, GraphicsFormat.R8G8B8A8_UNorm, enableRandomWrite: true, name: "_BakedDistortionTex2");
+                    if(bakedDistortionTexture2 != null)
+                        bakedDistortionTexture2.Release();
+                    bakedDistortionTexture2 = RTHandles.Alloc(resolution.x, resolution.y, GraphicsFormat.R8G8B8A8_UNorm, enableRandomWrite: true, name: "_BakedDistortionTex2");
+                    accentedMaterial.SetTexture(bakedDistortionTex2ShaderID, bakedDistortionTexture2);
                 }
             }
             
@@ -139,6 +150,17 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
                 bakedDistortionTexture2 = null;
             }
         }
+        private class BlitPassData
+        {
+            public Material mat;
+            public TextureHandle src;
+            public int passID;
+        }
+
+        private static void ExecuteBlitPass(BlitPassData passData, RasterGraphContext context)
+        {
+            Blitter.BlitTexture(context.cmd, passData.src, scaleBias, passData.mat, passData.passID);
+        }
         
         public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
         {
@@ -156,7 +178,7 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
             dstDesc.clearBuffer = true;
             dstDesc.msaaSamples = MSAASamples.None;
 
-            if (passData.ForceRebake)
+            if (passData.ForceRebake || ReValidateBakedTextures(dstDesc))
             {
                 sketchData.PrebakedDistortedUVs = false;
                 sketchData.PrebakedDistortedMultipleUVs = false;
@@ -167,22 +189,35 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
             bool shouldRebakeIfMultiple = passData.RequireMultipleTextures && !sketchData.PrebakedDistortedMultipleUVs;
             
             if(passData.BakeDistortionDuringRuntime && (shouldRebakeIfSingle || shouldRebakeIfMultiple))
-                ConfigureBakedTextures();
+                ConfigureBakedTextures(dstDesc, true);
             
             if (passData.BakeDistortionDuringRuntime && (shouldRebakeIfSingle || shouldRebakeIfMultiple))
             {
-                ImportResourceParams importParams = new ImportResourceParams();
-                TextureHandle distortedDst = renderGraph.ImportTexture(bakedDistortionTexture, importParams);
-                RenderGraphUtils.BlitMaterialParameters distortParams =
-                    new RenderGraphUtils.BlitMaterialParameters(sketchData.OutlinesTexture, distortedDst,
-                        accentedMaterial, 1);
-                renderGraph.AddBlitPass(distortParams, PassName + "_BakeUVDistortion");
-                
+                using (var builder = renderGraph.AddRasterRenderPass(PassName + "_BakeUVDistortion", out BlitPassData blitPassData))
+                {
+                    ImportResourceParams importParams = new ImportResourceParams();
+                    TextureHandle distortedDst = renderGraph.ImportTexture(bakedDistortionTexture, importParams);
+                    builder.UseTexture(sketchData.OutlinesTexture, AccessFlags.Read);
+                    blitPassData.mat = accentedMaterial;
+                    blitPassData.src = sketchData.OutlinesTexture;
+                    blitPassData.passID = 1;
+                    builder.SetRenderAttachment(distortedDst, 0);
+                    builder.SetRenderFunc((BlitPassData passData, RasterGraphContext context) => ExecuteBlitPass(passData, context));
+                }
+
                 if (shouldRebakeIfMultiple)
                 {
-                    TextureHandle distortedDst2 = renderGraph.ImportTexture(bakedDistortionTexture2);
-                    RenderGraphUtils.BlitMaterialParameters distortParams2 = new RenderGraphUtils.BlitMaterialParameters(sketchData.OutlinesTexture, distortedDst2, accentedMaterial, 1);
-                    renderGraph.AddBlitPass(distortParams2, PassName + "_BakeUVDistortion2");
+                    using (var builder = renderGraph.AddRasterRenderPass(PassName + "_BakeUVDistortion2", out BlitPassData blitPassData))
+                    {
+                        ImportResourceParams importParams = new ImportResourceParams();
+                        TextureHandle distortedDst2 = renderGraph.ImportTexture(bakedDistortionTexture2, importParams);
+                        builder.UseTexture(sketchData.OutlinesTexture, AccessFlags.Read);
+                        blitPassData.mat = accentedMaterial;
+                        blitPassData.src = sketchData.OutlinesTexture;
+                        blitPassData.passID = 1;
+                        builder.SetRenderAttachment(distortedDst2, 0);
+                        builder.SetRenderFunc((BlitPassData passData, RasterGraphContext context) => ExecuteBlitPass(passData, context));
+                    }
                 }
                 
                 sketchData.PrebakedDistortedUVs = shouldRebakeIfSingle;
@@ -194,11 +229,20 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
                 sketchData.PrebakedDistortedMultipleUVs = false;
             }
 
+
             TextureHandle dst = renderGraph.CreateTexture(dstDesc);
-            //This shader has a single pass that handles all behaviours (distortion, outline brightness and texture masking) by compile keywords
-            RenderGraphUtils.BlitMaterialParameters thickenParams =
-                new RenderGraphUtils.BlitMaterialParameters(sketchData.OutlinesTexture, dst, accentedMaterial, 0);
-            renderGraph.AddBlitPass(thickenParams, PassName);
+            using (var builder = renderGraph.AddRasterRenderPass(PassName, out BlitPassData blitPassData))
+            {
+                builder.UseTexture(sketchData.OutlinesTexture, AccessFlags.Read);
+                blitPassData.mat = accentedMaterial;
+                blitPassData.src = sketchData.OutlinesTexture;
+                blitPassData.passID = 0;
+                
+                //This shader has a single pass that handles all behaviours (distortion, outline brightness and texture masking) by compile keywords
+                builder.SetRenderAttachment(dst, 0);
+                builder.SetRenderFunc((BlitPassData passData, RasterGraphContext context) => ExecuteBlitPass(passData, context));
+            }
+
             sketchData.OutlinesTexture = dst;
         }
     }

--- a/Runtime/Rendering/RendererFeatures/Outlining/SmoothOutline/ThicknessDilationPass/ThicknessDilationRenderPass.cs
+++ b/Runtime/Rendering/RendererFeatures/Outlining/SmoothOutline/ThicknessDilationPass/ThicknessDilationRenderPass.cs
@@ -15,6 +15,10 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
         
         private static readonly int outlineSizeShaderID = Shader.PropertyToID("_OutlineSize");
         private static readonly int outlineStrengthShaderID = Shader.PropertyToID("_OutlineStrength");
+        
+        // Scale bias is used to control how the blit operation is done. The x and y parameter controls the scale
+        // and z and w controls the offset.
+        static Vector4 scaleBias = new Vector4(1f, 1f, 0f, 0f);
 
         public void Setup(ThicknessDilationPassData passData, Material mat)
         {
@@ -34,6 +38,18 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
         }
 
         public void Dispose() {}
+        
+        private class BlitPassData
+        {
+            public Material mat;
+            public TextureHandle src;
+            public int passID;
+        }
+
+        private static void ExecuteBlitPass(BlitPassData passData, RasterGraphContext context)
+        {
+            Blitter.BlitTexture(context.cmd, passData.src, scaleBias, passData.mat, passData.passID);
+        }
 
         public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
         {
@@ -52,9 +68,17 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
             dstDesc.msaaSamples = MSAASamples.None;
                 
             TextureHandle dst = renderGraph.CreateTexture(dstDesc);
-            
-            RenderGraphUtils.BlitMaterialParameters thickenParams = new RenderGraphUtils.BlitMaterialParameters(sketchData.OutlinesTexture, dst, dilationMaterial, 0);
-            renderGraph.AddBlitPass(thickenParams, PassName);
+
+            using (var builder = renderGraph.AddRasterRenderPass(PassName, out BlitPassData blitPassData))
+            {
+                builder.UseTexture(sketchData.OutlinesTexture);
+                blitPassData.mat = dilationMaterial;
+                blitPassData.passID = 0;
+                blitPassData.src = sketchData.OutlinesTexture;
+                
+                builder.SetRenderAttachment(dst, 0, AccessFlags.Write);
+                builder.SetRenderFunc((BlitPassData passData, RasterGraphContext context) => ExecuteBlitPass(passData, context));
+            }
             sketchData.OutlinesTexture = dst;
         }
     }

--- a/Runtime/Rendering/RendererFeatures/TextureProjection/Luminance/LuminanceRenderPass.cs
+++ b/Runtime/Rendering/RendererFeatures/TextureProjection/Luminance/LuminanceRenderPass.cs
@@ -184,7 +184,7 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
 
                 TextureHandle dst = renderGraph.CreateTexture(dstDesc);
 
-                builder.UseTexture(resourceData.activeColorTexture, AccessFlags.ReadWrite);
+                builder.UseTexture(resourceData.activeColorTexture, AccessFlags.Read);
                 passData.src = resourceData.activeColorTexture;
                 builder.SetRenderAttachment(dst, 0, AccessFlags.ReadWrite);
                 passData.dst = dst;

--- a/Runtime/Rendering/RendererFeatures/TextureProjection/MaterialSurface/MaterialSurfaceRenderPass.cs
+++ b/Runtime/Rendering/RendererFeatures/TextureProjection/MaterialSurface/MaterialSurfaceRenderPass.cs
@@ -141,7 +141,7 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
 
                 TextureHandle dst = renderGraph.CreateTexture(dstDesc);
                 
-                builder.UseTexture(resourceData.activeColorTexture, AccessFlags.ReadWrite);
+                builder.UseTexture(resourceData.activeColorTexture, AccessFlags.Read);
                 passData.src = resourceData.activeColorTexture;
                 builder.SetRenderAttachment(dst, 0, AccessFlags.ReadWrite);
                 passData.dst = dst;
@@ -177,7 +177,7 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
                 
                 TextureHandle directionalDst = renderGraph.CreateTexture(dstDesc);
                 
-                directionalBuilder.UseTexture(resourceData.activeColorTexture, AccessFlags.ReadWrite);
+                directionalBuilder.UseTexture(resourceData.activeColorTexture, AccessFlags.Read);
                 directionalPassData.src = resourceData.activeColorTexture;
                 directionalBuilder.SetRenderAttachment(directionalDst, 0, AccessFlags.ReadWrite);
                 directionalPassData.dst = directionalDst;

--- a/Runtime/Rendering/Volume/Outlining/SmoothOutlineVolumeComponent.cs
+++ b/Runtime/Rendering/Volume/Outlining/SmoothOutlineVolumeComponent.cs
@@ -15,9 +15,10 @@ namespace SketchRenderer.Runtime.Rendering.Volume
         [Header("Accented Outlines - Thickness")]
         public ClampedIntParameter ThicknessRange = new ClampedIntParameter(0, 0, 5);
         public ClampedFloatParameter ThicknessStrength = new ClampedFloatParameter(0, 0, 1);
-        [Space(2.5f)]
-        [Header("Accented Outlines - Distortion")]
+
+        [Space(2.5f)] [Header("Accented Outlines - Distortion")]
         public BoolParameter BakeDistortion = new BoolParameter(false);
+        public FloatParameter BakedDistortionTextureScale = new ClampedFloatParameter(1f, 0.25f, 1f);
         public FloatParameter DistortionRate = new FloatParameter(20f);
         public ClampedFloatParameter DistortionStrength = new ClampedFloatParameter(0, 0, 1);
         public ClampedIntParameter AdditionalDistortionLines = new ClampedIntParameter(0, 0, 3);


### PR DESCRIPTION
Ported all edge detection variant passes and other renderer features which were made using native passes to rendergraph wherever possible, to allow for automatic pass combination.

Fixed dynamic scaling causing baked distortion buffers from being cleared and not rebaked. The buffers are now created at a static resolution and are checked if rebaking is necessary dynamically at execution. Additionally allowed the accented outline pass to determine a scaling factor when creating the textures.

Also made the stroke blending with luminance and material not break completely when using non-dark colors (by actually doing real blending).

Closes #14.