### PR TITLE
Tweaks to RenderUVs feature and texture projection.

### DIFF
--- a/Editor/Rendering/PassData/LuminancePassDataDrawer.cs
+++ b/Editor/Rendering/PassData/LuminancePassDataDrawer.cs
@@ -31,7 +31,7 @@ namespace SketchRenderer.Editor.Rendering
             var projectionField = SketchRendererUI.SketchEnumProperty(projectionProp, method); 
             projectionField.Field.RegisterValueChangedCallback(_ => ForceRepaint());
             SketchRendererUIUtils.AddWithMargins(projectionRegion, projectionField.Container, SketchRendererUIData.MajorIndentCorners);
-            if (method is TextureProjectionGlobalData.TextureProjectionMethod.OBJECT_SPACE_CONSTANT_SCALE or TextureProjectionGlobalData.TextureProjectionMethod.OBJECT_SPACE_REVERSED_CONSTANT_SCALE)
+            if (method is TextureProjectionGlobalData.TextureProjectionMethod.OBJECT_SPACE_CONSTANT_SCALE) //or TextureProjectionGlobalData.TextureProjectionMethod.OBJECT_SPACE_REVERSED_CONSTANT_SCALE)
             {
                 var falloffField = SketchRendererUI.SketchFloatSliderPropertyWithInput(property.FindPropertyRelative("ConstantScaleFalloffFactor"), nameOverride:"Falloff Factor");
                 SketchRendererUIUtils.AddWithMargins(projectionRegion, falloffField.Container, SketchRendererUIData.MajorIndentCorners);

--- a/Editor/Rendering/PassData/MaterialSurfacePassDataDrawer.cs
+++ b/Editor/Rendering/PassData/MaterialSurfacePassDataDrawer.cs
@@ -27,7 +27,7 @@ namespace SketchRenderer.Editor.Rendering
             var projectionField = SketchRendererUI.SketchEnumProperty(projectionProp, method); 
             projectionField.Field.RegisterValueChangedCallback(_ => ForceRepaint());
             SketchRendererUIUtils.AddWithMargins(projectionRegion, projectionField.Container, SketchRendererUIData.MajorIndentCorners);
-            if (method is TextureProjectionGlobalData.TextureProjectionMethod.OBJECT_SPACE_CONSTANT_SCALE or TextureProjectionGlobalData.TextureProjectionMethod.OBJECT_SPACE_REVERSED_CONSTANT_SCALE)
+            if (method is TextureProjectionGlobalData.TextureProjectionMethod.OBJECT_SPACE_CONSTANT_SCALE) //or TextureProjectionGlobalData.TextureProjectionMethod.OBJECT_SPACE_REVERSED_CONSTANT_SCALE)
             {
                 var falloffField = SketchRendererUI.SketchFloatSliderPropertyWithInput(property.FindPropertyRelative("ConstantScaleFalloffFactor"), nameOverride:"Falloff Factor");
                 SketchRendererUIUtils.AddWithMargins(projectionRegion, falloffField.Container, SketchRendererUIData.MajorIndentCorners);

--- a/Editor/Rendering/PassData/RenderUVsPassDataDrawer.cs
+++ b/Editor/Rendering/PassData/RenderUVsPassDataDrawer.cs
@@ -12,9 +12,13 @@ namespace SketchRenderer.Editor.Rendering
         {
             var passDataField = new VisualElement();
             
-            SerializedProperty skyboxRotationProp = property.FindPropertyRelative("SkyboxRotation");
-            var skyboxRotationField = SketchRendererUI.SketchFloatSliderPropertyWithInput(skyboxRotationProp);
+            SerializedProperty skyboxRotationProp = property.FindPropertyRelative("SkyboxRotationStep");
+            var skyboxRotationField = SketchRendererUI.SketchIntSliderPropertyWithInput(skyboxRotationProp, nameOverride:"Skybox Orientation");
             SketchRendererUIUtils.AddWithMargins(passDataField, skyboxRotationField.Container, CornerData.Empty);
+            
+            SerializedProperty skyboxScaleProp = property.FindPropertyRelative("SkyboxScale");
+            var skyboxScaleField = SketchRendererUI.SketchIntegerProperty(skyboxScaleProp);
+            SketchRendererUIUtils.AddWithMargins(passDataField, skyboxScaleField.Container, CornerData.Empty);
             
             return passDataField;
         }

--- a/Runtime/Rendering/RendererFeatures/RenderUVs/RenderUVsPassData.cs
+++ b/Runtime/Rendering/RendererFeatures/RenderUVs/RenderUVsPassData.cs
@@ -7,9 +7,12 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
     [System.Serializable]
     public class RenderUVsPassData : ISketchRenderPassData<RenderUVsPassData>
     {
-        [Header("Base Parameters")] 
+        [Range(0, 3)]
+        public int SkyboxRotationStep = 0;
         [Range(0, 360)]
-        public float SkyboxRotation;
+        private float SkyboxRotation => (float)SkyboxRotationStep * 120f;
+
+        public int SkyboxScale;
         private float ExpectedRotation { get {return Mathf.Floor(SkyboxRotation/90) * 90;}}
         [HideInInspector] 
         public Matrix4x4 SkyboxRotationMatrix;
@@ -22,9 +25,16 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
             }
         }
 
+        public RenderUVsPassData()
+        {
+            SkyboxRotationStep = 0;
+            SkyboxScale = 10;
+        }
+
         public void CopyFrom(RenderUVsPassData passData)
         {
-            SkyboxRotation = passData.SkyboxRotation;
+            SkyboxRotationStep = passData.SkyboxRotationStep;
+            SkyboxScale = passData.SkyboxScale;
             SkyboxRotationMatrix = ConstructRotationMatrix(ExpectedRotation);
         }
     
@@ -37,13 +47,9 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
         {
             if(VolumeManager.instance == null || VolumeManager.instance.stack == null)
                 return this;
-            LuminanceVolumeComponent volumeComponent = VolumeManager.instance.stack.GetComponent<LuminanceVolumeComponent>();
-            if (volumeComponent != null)
-                SkyboxRotation = volumeComponent.SkyboxRotation.overrideState ? Mathf.Lerp(0, 360,volumeComponent.SkyboxRotation.value) : SkyboxRotation;
+
             if (ShouldRotate)
-            {
                 SkyboxRotationMatrix = ConstructRotationMatrix(ExpectedRotation);
-            }
 
             return this;
         }

--- a/Runtime/Rendering/RendererFeatures/RenderUVs/RenderUVsRenderPass.cs
+++ b/Runtime/Rendering/RendererFeatures/RenderUVs/RenderUVsRenderPass.cs
@@ -15,6 +15,7 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
         private Material uvsMaterial;
 
         private readonly int ROTATION_MATRIX_ID = Shader.PropertyToID("_SkyboxRotationMatrix");
+        private readonly int SCALE_ID = Shader.PropertyToID("_SkyboxScale");
         private readonly string ROTATE_SKYBOX_ID = "ROTATE_SKYBOX";
         
         private LocalKeyword RotateSkyboxKeyword;
@@ -45,6 +46,8 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
             }
             else
                 uvsMaterial.SetKeyword(RotateSkyboxKeyword, false);
+            
+            uvsMaterial.SetInteger(SCALE_ID, passData.SkyboxScale);
         }
 
         public void Dispose()
@@ -83,7 +86,7 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
 
                 TextureDesc desc = renderGraph.GetTextureDesc(resourceData.activeColorTexture);
                 desc.name = SketchGlobalFrameData.ScreenUVTexture.TextureName;
-                desc.format = GraphicsFormat.R32G32_SFloat;
+                desc.format = GraphicsFormat.R32G32B32A32_SFloat;
                 desc.msaaSamples = MSAASamples.None;
                 TextureHandle dst = renderGraph.CreateTexture(desc);
                 

--- a/Runtime/Rendering/RendererFeatures/TextureProjection/Luminance/LuminanceRenderPass.cs
+++ b/Runtime/Rendering/RendererFeatures/TextureProjection/Luminance/LuminanceRenderPass.cs
@@ -128,12 +128,14 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
                     luminanceMat.SetKeyword(UVsObjectSpaceConstantKeyword, true);
                     luminanceMat.SetKeyword(UVsObjectSpaceReversedConstantKeyword, false);
                     break;
+                /*
                 case TextureProjectionGlobalData.TextureProjectionMethod.OBJECT_SPACE_REVERSED_CONSTANT_SCALE:
                     luminanceMat.SetKeyword(UVsScreenSpaceKeyword, false);
                     luminanceMat.SetKeyword(UVsObjectSpaceKeyword, false);
                     luminanceMat.SetKeyword(UVsObjectSpaceConstantKeyword, false);
                     luminanceMat.SetKeyword(UVsObjectSpaceReversedConstantKeyword, true);
                     break;
+                    */
             }
 
             luminanceMat.SetKeyword(QuantizeKeyword, !passData.SmoothTransitions);

--- a/Runtime/Rendering/RendererFeatures/TextureProjection/MaterialSurface/MaterialSurfaceRenderPass.cs
+++ b/Runtime/Rendering/RendererFeatures/TextureProjection/MaterialSurface/MaterialSurfaceRenderPass.cs
@@ -75,12 +75,14 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
                     materialMat.SetKeyword(UVsObjectSpaceConstantKeyword, true);
                     materialMat.SetKeyword(UVsObjectSpaceReversedConstantKeyword, false);
                     break;
+                /*
                 case TextureProjectionGlobalData.TextureProjectionMethod.OBJECT_SPACE_REVERSED_CONSTANT_SCALE:
                     materialMat.SetKeyword(UVsScreenSpaceKeyword, false);
                     materialMat.SetKeyword(UVsObjectSpaceKeyword, false);
                     materialMat.SetKeyword(UVsObjectSpaceConstantKeyword, false);
                     materialMat.SetKeyword(UVsObjectSpaceReversedConstantKeyword, true);
                     break;
+                    */
             }
             
             materialMat.SetFloat(TextureProjectionGlobalData.CONSTANT_SCALE_FALLOFF_SHADER_ID, passData.ConstantScaleFalloffFactor);
@@ -122,8 +124,8 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
 
                 if (this.passData.ProjectionMethod 
                     is TextureProjectionGlobalData.TextureProjectionMethod.OBJECT_SPACE
-                    or TextureProjectionGlobalData.TextureProjectionMethod.OBJECT_SPACE_CONSTANT_SCALE
-                    or TextureProjectionGlobalData.TextureProjectionMethod.OBJECT_SPACE_REVERSED_CONSTANT_SCALE)
+                    or TextureProjectionGlobalData.TextureProjectionMethod.OBJECT_SPACE_CONSTANT_SCALE)
+                    //or TextureProjectionGlobalData.TextureProjectionMethod.OBJECT_SPACE_REVERSED_CONSTANT_SCALE)
                 {
                     //Preemptive check to avoid exception from breaking blitter
                     try

--- a/Runtime/Rendering/RendererFeatures/TextureProjection/TextureProjectionGlobalData.cs
+++ b/Runtime/Rendering/RendererFeatures/TextureProjection/TextureProjectionGlobalData.cs
@@ -7,7 +7,7 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
     {
         public enum TextureProjectionMethod
         {
-            SCREEN_SPACE, OBJECT_SPACE, OBJECT_SPACE_CONSTANT_SCALE, OBJECT_SPACE_REVERSED_CONSTANT_SCALE
+            SCREEN_SPACE, OBJECT_SPACE, OBJECT_SPACE_CONSTANT_SCALE//, OBJECT_SPACE_REVERSED_CONSTANT_SCALE
         }
     
         public static readonly string UVS_SCREEN_SPACE_KEYWORD = "UVS_SCREEN_SPACE";
@@ -25,7 +25,7 @@ namespace SketchRenderer.Runtime.Rendering.RendererFeatures
                     return false;
                 case TextureProjectionMethod.OBJECT_SPACE:
                 case TextureProjectionMethod.OBJECT_SPACE_CONSTANT_SCALE:
-                case TextureProjectionMethod.OBJECT_SPACE_REVERSED_CONSTANT_SCALE:
+                //case TextureProjectionMethod.OBJECT_SPACE_REVERSED_CONSTANT_SCALE:
                     return true;
             }
             return false;

--- a/Runtime/Rendering/Volume/LuminanceVolumeComponent.cs
+++ b/Runtime/Rendering/Volume/LuminanceVolumeComponent.cs
@@ -15,7 +15,6 @@ namespace SketchRenderer.Runtime.Rendering.Volume
         public ClampedFloatParameter ConstantScaleFalloffFactor = new ClampedFloatParameter(0f, 1f, 5f);
         public BoolParameter SmoothTransitions = new BoolParameter(false);
         public NoInterpVector2Parameter ToneScales = new NoInterpVector2Parameter(Vector2.one);
-        public ClampedFloatParameter SkyboxRotation = new ClampedFloatParameter(0, 0, 1);
         public ClampedFloatParameter LuminanceOffset = new ClampedFloatParameter(0f, -1f, 1f);
     }
 }

--- a/Shader/Luminance/Luminance.shader
+++ b/Shader/Luminance/Luminance.shader
@@ -31,7 +31,8 @@ Shader "SketchRenderer/Luminance"
                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
                float2 screenSpaceUV = input.texcoord;
                #if defined UVS_OBJECT_SPACE || defined UVS_OBJECT_SPACE_CONSTANT || defined UVS_OBJECT_SPACE_REVERSED_CONSTANT
-               float2 objectUVs = SAMPLE_TEXTURE2D_X_LOD(_CameraUVsTexture, sampler_PointClamp, screenSpaceUV, _BlitMipLevel).xy;
+               float3 objectUVsMip = SAMPLE_TEXTURE2D_X_LOD(_CameraUVsTexture, sampler_PointClamp, screenSpaceUV, _BlitMipLevel).xyz;
+               objectUVsMip.z = GetMipLevel(objectUVsMip.z, max(_Tam0_2_TexelSize.z, _Tam0_2_TexelSize.w));
                #endif
 
                //get pixel luminance: https://stackoverflow.com/questions/596216/formula-to-determine-perceived-brightness-of-rgb-color
@@ -45,9 +46,9 @@ Shader "SketchRenderer/Luminance"
                #endif
 
                #if defined UVS_OBJECT_SPACE || defined UVS_OBJECT_SPACE_CONSTANT || defined UVS_OBJECT_SPACE_REVERSED_CONSTANT
-               float stroke = SampleTAM(lum, _NumTones, objectUVs);
+               float stroke = SampleTAM(lum, _NumTones, objectUVsMip.xy, objectUVsMip.z);
                #else
-               float stroke = SampleTAM(lum, _NumTones, screenSpaceUV);
+               float stroke = SampleTAM(lum, _NumTones, screenSpaceUV, _BlitMipLevel);
                #endif
                
                return float4(stroke.rrrr);

--- a/Shader/Luminance/TAMSampleInclude.hlsl
+++ b/Shader/Luminance/TAMSampleInclude.hlsl
@@ -27,7 +27,7 @@ float3 GetWeightsFromQuantizedLuminance(float luminance, int tones, int offset)
     return saturate(luminance3 - weights);
 }
 
-float SingleTAMSample(float luminance, int tones, float2 uv)
+float SingleTAMSample(float luminance, int tones, float2 uv, float mip)
 {
     float4 tam0_2 = SAMPLE_TEX(_Tam0_2, sampler_PointRepeat, _Tam0_2_TexelSize.z, _BlitMipLevel, uv, _TamScales);
     float3 toneWeights = GetWeightsFromQuantizedLuminance(luminance, tones, 0);
@@ -36,7 +36,7 @@ float SingleTAMSample(float luminance, int tones, float2 uv)
     return 1 - (col.r + col.g + col.b);
 }
 
-float DoubleTAMSample(float luminance, int tones, float2 uv)
+float DoubleTAMSample(float luminance, int tones, float2 uv, float mip)
 {
     float4 tam0_2 = SAMPLE_TEX(_Tam0_2, sampler_PointRepeat, _Tam0_2_TexelSize.z, _BlitMipLevel, uv, _TamScales);
     float4 tam3_5 = SAMPLE_TEX(_Tam3_5, sampler_PointRepeat, _Tam3_5_TexelSize.z, _BlitMipLevel, uv, _TamScales);
@@ -50,7 +50,7 @@ float DoubleTAMSample(float luminance, int tones, float2 uv)
     return 1 - (col1.r + col1.g + col1.b + col2.r + col2.g + col2.b);
 }
 
-float TripleTAMSample(float luminance, int tones, float2 uv)
+float TripleTAMSample(float luminance, int tones, float2 uv, float mip)
 {
     float4 tam0_2 = SAMPLE_TEX(_Tam0_2, sampler_PointRepeat, _Tam0_2_TexelSize.z, _BlitMipLevel, uv, _TamScales);
     float4 tam3_5 = SAMPLE_TEX(_Tam3_5, sampler_PointRepeat, _Tam3_5_TexelSize.z, _BlitMipLevel, uv, _TamScales);
@@ -69,15 +69,15 @@ float TripleTAMSample(float luminance, int tones, float2 uv)
     return 1 - (col1.r + col1.g + col1.b + col2.r + col2.g + col2.b + col3.r + col3.g + col3.b);
 }
 
-float SampleTAM(float luminance, int tones, float2 uv)
+float SampleTAM(float luminance, int tones, float2 uv, float mip)
 {
     #if defined TAM_DOUBLE
-    return DoubleTAMSample(luminance, tones, uv);
+    return DoubleTAMSample(luminance, tones, uv, mip);
     #elif defined TAM_TRIPLE
-    return TripleTAMSample(luminance, tones, uv);
+    return TripleTAMSample(luminance, tones, uv, mip);
     #endif
 
-    return SingleTAMSample(luminance, tones, uv);
+    return SingleTAMSample(luminance, tones, uv, mip);
 }
 
 #endif

--- a/Shader/MaterialSurface.shader
+++ b/Shader/MaterialSurface.shader
@@ -32,13 +32,15 @@ Shader "SketchRenderer/MaterialSurface"
                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
                float2 screenSpaceUV = input.texcoord;
                float2 uv = screenSpaceUV;
+               float mip = _BlitMipLevel;
                #if defined UVS_OBJECT_SPACE || defined UVS_OBJECT_SPACE_CONSTANT || defined UVS_OBJECT_SPACE_REVERSED_CONSTANT
-               float2 objectUVs = SAMPLE_TEXTURE2D_X_LOD(_CameraUVsTexture, sampler_PointClamp, screenSpaceUV, _BlitMipLevel).xy;
-               uv = objectUVs;
+               float3 objectUVsMip = SAMPLE_TEXTURE2D_X_LOD(_CameraUVsTexture, sampler_PointClamp, screenSpaceUV, _BlitMipLevel).xyz;
+               uv = objectUVsMip.xy;
+               mip = GetMipLevel(objectUVsMip.z, max(_MaterialAlbedoTex_TexelSize.z, _MaterialAlbedoTex_TexelSize.w));
                #endif
                
                float4 col = SAMPLE_TEXTURE2D_X_LOD(_BlitTexture, sampler_PointClamp, screenSpaceUV, _BlitMipLevel);
-               float4 albedo = SAMPLE_TEX(_MaterialAlbedoTex, sampler_PointRepeat, _MaterialAlbedoTex_TexelSize.z, _BlitMipLevel, uv, _TextureScales);
+               float4 albedo = SAMPLE_TEX(_MaterialAlbedoTex, sampler_PointRepeat, _MaterialAlbedoTex_TexelSize.z, mip, uv, _TextureScales);
 
                float4 final = lerp(albedo, col, _BlendStrength);
                return float4(final.rgba);
@@ -75,12 +77,14 @@ Shader "SketchRenderer/MaterialSurface"
                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
                float2 screenSpaceUV = input.texcoord;
                float2 uv = screenSpaceUV;
+               float mip = _BlitMipLevel;
                #if defined UVS_OBJECT_SPACE || defined UVS_OBJECT_SPACE_CONSTANT
-               float2 objectUVs = SAMPLE_TEXTURE2D_X_LOD(_CameraUVsTexture, sampler_PointClamp, screenSpaceUV, _BlitMipLevel).xy;
-               uv = objectUVs;
+               float3 objectUVsMip = SAMPLE_TEXTURE2D_X_LOD(_CameraUVsTexture, sampler_PointClamp, screenSpaceUV, _BlitMipLevel).xyz;
+               uv = objectUVsMip.xy;
+               mip = GetMipLevel(objectUVsMip.z, max(_MaterialDirectionalTex_TexelSize.z, _MaterialDirectionalTex_TexelSize.w));
                #endif
 
-               float4 direction = SAMPLE_TEX(_MaterialDirectionalTex, sampler_PointRepeat, _MaterialDirectionalTex_TexelSize.z, _BlitMipLevel, uv, _TextureScales);
+               float4 direction = SAMPLE_TEX(_MaterialDirectionalTex, sampler_PointRepeat, _MaterialDirectionalTex_TexelSize.z, mip, uv, _TextureScales);
                direction = float4(UnpackNormal(direction), 0.0);
                direction *= 0.5;
                direction += 0.5;

--- a/ShaderLibrary/TextureOperations.hlsl
+++ b/ShaderLibrary/TextureOperations.hlsl
@@ -58,3 +58,16 @@ float4 ConstantScaleTexture2DSample(Texture2D tex, SamplerState samp, float texe
     float4 sample = lerp(s1, s2, scales.z);
     return sample;
 }
+
+float GetMipFactor(float2 uv)
+{
+    float2 uvdx = ddx(uv);
+    float2 uvdy = ddy(uv);
+    float factor = max(length(uvdx), length(uvdy));
+    return factor;
+}
+
+float GetMipLevel(float factor, float maxTextureDimension)
+{
+    return log2(factor * maxTextureDimension);
+}


### PR DESCRIPTION
Modified RenderUVs pass to add individual scaling control as well as mapping the expected mip factor.
Texture projection features now calculate texture mip levels when sampling with constant scale.
Removed reverse constant scale as it was breaking in multiple situations and the desired effect can be achived by using fractional factors in constant scale mode.